### PR TITLE
#413 ("in old money") Fall back to null SDK rather than mouse SDK.

### DIFF
--- a/lib/Microsoft.HandsFree.Sensors/GazeDataProvider.cs
+++ b/lib/Microsoft.HandsFree.Sensors/GazeDataProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.HandsFree.Sensors
 
             if (!gazeDataProvider.Initialize())
             {
-                gazeDataProvider = new MouseSdk();
+                gazeDataProvider = new NullSdk();
                 var ret = gazeDataProvider.Initialize();
                 Debug.Assert(ret);               
             }


### PR DESCRIPTION
Falling back to the Mouse SDK causes unwanted interactions between a "normal" mouse and non-clicking "head" mouse behaviors. Falling back to relying on normal clicks allows easier development and recovery from broken installation problems as unfortunate unintended clicks will not occur. This does require that head mice are explicitly selected, rather than being implicitly detected.