### PR TITLE
Bug fix: calculate kalmanGain.Y

### DIFF
--- a/lib/Microsoft.HandsFree.Filters/SimpleKalmanFilter.cs
+++ b/lib/Microsoft.HandsFree.Filters/SimpleKalmanFilter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.HandsFree.Filters
             }
 
             _kalmanGain.X = _estimateCovariance.X / (_estimateCovariance.X + _measurementCovariance.X);
-            _kalmanGain.X = _estimateCovariance.Y / (_estimateCovariance.Y + _measurementCovariance.Y);
+            _kalmanGain.Y = _estimateCovariance.Y / (_estimateCovariance.Y + _measurementCovariance.Y);
             _filteredX = _filteredX + _kalmanGain.X * (measuredX - _filteredX);
             _filteredY = _filteredY + _kalmanGain.Y * (measuredY - _filteredY);
             _estimateCovariance.X = (1 - _kalmanGain.X) * _estimateCovariance.X;


### PR DESCRIPTION
Previously, `_kalmanGain.Y` was never actually calculated. This caused the covariance matrix to never be updated with the correct values. Granted, this doesn't really matter, because the covariance matrix in this Kalman filter will always converge on a fixed value (the Kalman gain and covariance are independent of the gaze input in this formulation).